### PR TITLE
Fixed dark mode theme inconsistencies and corrected broken image path

### DIFF
--- a/js-practice-platform/src/components/Navbar.jsx
+++ b/js-practice-platform/src/components/Navbar.jsx
@@ -97,7 +97,7 @@ const Navbar = () => {
             <img
               src={Logo}
               alt="JS Practice Platform"
-              className="w-12 h-12 object-contain rounded-lg shadow-md"
+              className="w-12 h-12 object-fit rounded-lg shadow-md"
             />
             <h1 className="text-xl font-bold text-gray-100 dark:text-gray-800 hidden sm:block">
               JS Practice Platform

--- a/js-practice-platform/src/components/Navbar.jsx
+++ b/js-practice-platform/src/components/Navbar.jsx
@@ -17,6 +17,7 @@ import {
   X
 } from 'lucide-react';
 import { toggleDarkMode } from '../store/slices/themeSlice';
+import Logo from '../assets/Logo.png';
 import { logout } from '../store/slices/authSlice';
 import AuthModal from './AuthModal';
 
@@ -93,9 +94,9 @@ const Navbar = () => {
             >
               <Menu size={24} />
             </button>
-            <img 
-              src="/Logo.png" 
-              alt="JS Practice Platform" 
+            <img
+              src={Logo}
+              alt="JS Practice Platform"
               className="w-12 h-12 object-contain rounded-lg shadow-md"
             />
             <h1 className="text-xl font-bold text-gray-900 dark:text-white hidden sm:block">
@@ -149,9 +150,9 @@ const Navbar = () => {
         <div className="navbar-header">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">
-              <img 
-                src="/Logo.png" 
-                alt="JS Practice Platform" 
+              <img
+                src={Logo}
+                alt="JS Practice Platform"
                 className="w-10 h-10 object-contain rounded-lg shadow-sm"
               />
               <span className="text-white font-semibold text-lg">JS Practice</span>

--- a/js-practice-platform/src/components/Navbar.jsx
+++ b/js-practice-platform/src/components/Navbar.jsx
@@ -99,7 +99,7 @@ const Navbar = () => {
               alt="JS Practice Platform"
               className="w-12 h-12 object-contain rounded-lg shadow-md"
             />
-            <h1 className="text-xl font-bold text-gray-900 dark:text-white hidden sm:block">
+            <h1 className="text-xl font-bold text-gray-100 dark:text-gray-800 hidden sm:block">
               JS Practice Platform
             </h1>
           </div>

--- a/js-practice-platform/src/components/QuestionList.jsx
+++ b/js-practice-platform/src/components/QuestionList.jsx
@@ -81,8 +81,8 @@ const QuestionList = ({ category, title, description }) => {
   return (
     <div className="question-list-container">
       <div className="mb-8">
-        <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-3">{title}</h1>
-        <p className="text-gray-600 dark:text-gray-400 text-lg">{description}</p>
+        <h1 className="text-3xl font-bold text-gray-100 dark:text-gray-800 mb-3">{title}</h1>
+        <p className="text-gray-100 dark:text-gray-800 text-lg">{description}</p>
         <div className="mt-4 flex items-center gap-4 text-sm text-gray-500 dark:text-gray-400">
           <span className="flex items-center gap-1">
             <Code size={16} />

--- a/js-practice-platform/src/pages/Dashboard.jsx
+++ b/js-practice-platform/src/pages/Dashboard.jsx
@@ -90,7 +90,7 @@ const Dashboard = () => {
   return (
     <div className="dashboard">
       <div className="dashboard-header mb-8">
-        <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2">
+        <h1 className="text-3xl font-bold text-gray-100 dark:text-gray-800 mb-2">
           Welcome to JavaScript Practice Platform
         </h1>
         <p className="text-gray-600 dark:text-gray-400 text-lg">
@@ -109,7 +109,7 @@ const Dashboard = () => {
                   <p className="text-sm font-medium text-gray-600 dark:text-gray-400 mb-1">
                     {stat.title}
                   </p>
-                  <p className="text-2xl font-bold text-gray-900 dark:text-white">
+                  <p className="text-2xl font-bold text-gray-100 dark:text-gray-800">
                     {stat.value}
                   </p>
                 </div>
@@ -161,7 +161,7 @@ const Dashboard = () => {
 
       {/* Recent Activity Section */}
       <div className="mt-12">
-        <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-6">
+        <h2 className="text-2xl font-bold text-gray-100 dark:text-gray-800 mb-6">
           Recent Activity
         </h2>
         <div className="card">

--- a/js-practice-platform/src/styles/main.css
+++ b/js-practice-platform/src/styles/main.css
@@ -580,6 +580,7 @@ body {
 .text-gray-900 { color: #111827; }
 .text-white { color: white; }
 .text-red-500 { color: #ef4444; }
+.text-purple-600 { color: #8E24AA; }
 .text-green-600 { color: #16a34a; }
 .text-blue-600 { color: #2563eb; }
 .text-yellow-600 { color: #ca8a04; }


### PR DESCRIPTION
**Description:**

This PR fixes the following issues:

-  Resolved missing or incorrect color variables when switching between light and dark themes.
-  Fixed a broken logo image path for consistent display across all pages.
-  Verified that all UI elements remain visible and contrast-compliant in both modes.

Closes #16 

Manually verified across all main pages with theme toggling enabled.

<img width="1560" height="130" alt="image" src="https://github.com/user-attachments/assets/043982e3-8101-4560-8b01-8c367d5ef8eb" />

<img width="1574" height="135" alt="image" src="https://github.com/user-attachments/assets/1200292c-d679-4428-b736-95aef0299d58" />

<img width="1918" height="960" alt="image" src="https://github.com/user-attachments/assets/c8100f3d-8417-4306-bd49-6887bd3ac9d6" />

<img width="1916" height="327" alt="image" src="https://github.com/user-attachments/assets/8021deec-a7e8-4e94-a682-0aeee0c77d75" />

<img width="1899" height="348" alt="image" src="https://github.com/user-attachments/assets/4753af78-b6fd-4362-9d15-aa82d9f41b4e" />

<img width="1902" height="907" alt="Screenshot 2025-10-06 061451" src="https://github.com/user-attachments/assets/4ae6adc1-8347-40fc-a9fb-551194d63d3f" />
